### PR TITLE
Fix UnicodeDecodeError with non UTF-8 messages

### DIFF
--- a/infinigpt.py
+++ b/infinigpt.py
@@ -72,6 +72,10 @@ class InfiniGPT(SingleServerIRCBot):
             event (IRCEvent): Event details from the server.
         """
         self.log(f"Connected to {self.server}")
+        # Avoid UnicodeDecodeError when encountering non UTF-8 input
+        if hasattr(connection, "buffer"):
+            connection.buffer.errors = "replace"
+            self.log("Connection buffer errors set to 'replace'")
         if self.password != None:
             connection.privmsg("NickServ", f"IDENTIFY {self.password}")
             self.log("Identifying to NickServ")

--- a/infinigpt.py
+++ b/infinigpt.py
@@ -75,7 +75,7 @@ class InfiniGPT(SingleServerIRCBot):
         # Avoid UnicodeDecodeError when encountering non UTF-8 input
         if hasattr(connection, "buffer"):
             connection.buffer.errors = "replace"
-            self.log("Connection buffer errors set to 'replace'")
+            
         if self.password != None:
             connection.privmsg("NickServ", f"IDENTIFY {self.password}")
             self.log("Identifying to NickServ")


### PR DESCRIPTION
## Summary
- avoid UnicodeDecodeError by setting connection buffer to replace undecodable byte sequences

## Testing
- `python -m py_compile infinigpt.py`

------
https://chatgpt.com/codex/tasks/task_e_685e4ee49070832794b9ac49897ba369